### PR TITLE
Fix/Deployment named command line args

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,27 @@
+## Setup Bash variables
+
+Change to your account (set up through [near-cli](https://docs.near.org/docs/tools/near-cli)):
+
+```bash
+ACCOUNT=account.testnet
+ORACLE=oracle.account.testnet
+REQUESTOR=requestor.account.testnet
+```
+
+## Deployment
+
+The default parameters of `deploy_oracle.sh` are listed inside the script; change them with shell arguments, e.g. `--validityBond 1`. Testnet is used unless specified otherwise. Example deployment using the shell variables at the top:
+
+```bash
+bash deployment/deploy_oracle.sh --accountId $ORACLE --gov $ACCOUNT
+
+bash deployment/deploy_requestor.sh --accountId $REQUESTOR
+```
+
+## Reset account
+
+Example resetting (deleting then creating) the oracle account:
+
+```bash
+bash deployment/reset_account.sh --master $ACCOUNT --account $ORACLE
+```

--- a/deployment/deploy_oracle.sh
+++ b/deployment/deploy_oracle.sh
@@ -1,1 +1,31 @@
-NEAR_ENV=$1 near deploy --accountId $2 --wasmFile ./res/oracle.wasm --initFunction new --initArgs '{ "config": { "gov": "flux-dev", "final_arbitrator": "flux-dev", "stake_token": "v2.wnear.flux-dev", "payment_token": "v2.wnear.flux-dev", "validity_bond": "1000000000000000000000000", "max_outcomes": 8, "default_challenge_window_duration": "120000000000", "min_initial_challenge_window_duration": "120000000000", "final_arbitrator_invoke_amount": "100000000000000000000000000", "resolution_fee_percentage": 5000, "fee": {"flux_market_cap": "10000000000000", "total_value_staked":"1000", "resolution_fee_percentage": 1000 } } }'
+#!/bin/bash
+
+# default params
+network=${network:-testnet}
+accountId=${accountId:-oracle.account.testnet}
+gov=${gov:-flux-dev}
+finalArbitrator=${finalArbitrator:-flux-dev}
+stakeToken=${stakeToken:-v2.wnear.flux-dev}
+paymentToken=${paymentToken:-v2.wnear.flux-dev}
+validityBond=${validityBond:-1000000000000000000000000}
+maxOutcomes=${maxOutcomes:-8}
+defaultChallengeWindowDuration=${defaultChallengeWindowDuration:-120000000000}
+minInitialChallengeWindowDuration=${minInitialChallengeWindowDuration:-120000000000}
+finalArbitratorInvokeAmount=${finalArbitratorInvokeAmount:-100000000000000000000000000}
+# resolutionFeePercentage=${resolutionFeePercentage:-5000}
+fluxMarketCap=${fluxMarketCap:-10000000000000}
+totalValueStaked=${totalValueStaked:-1000}
+resolutionFeePercentage=${totalValueStaked:-1000}
+
+while [ $# -gt 0 ]; do
+
+   if [[ $1 == *"--"* ]]; then
+        param="${1/--/}"
+        declare $param="$2"
+        # echo $1 $2 // Optional to see the parameter:value result
+   fi
+
+  shift
+done
+
+NEAR_ENV=$network near deploy --accountId $accountId --wasmFile ./res/oracle.wasm --initFunction new --initArgs '{ "config": { "gov": "'$gov'", "final_arbitrator": "'$finalArbitrator'", "stake_token": "'$stakeToken'", "payment_token": "'$paymentToken'", "validity_bond": "'$validityBond'", "max_outcomes": '$maxOutcomes', "default_challenge_window_duration": "'$defaultChallengeWindowDuration'", "min_initial_challenge_window_duration": "'$minInitialChallengeWindowDuration'", "final_arbitrator_invoke_amount": "'$finalArbitratorInvokeAmount'", "resolution_fee_percentage": '$resolutionFeePercentage', "fee": {"flux_market_cap": "'$fluxMarketCap'", "total_value_staked":"'$totalValueStaked'", "resolution_fee_percentage": '$resolutionFeePercentage' } } }'

--- a/deployment/deploy_requestor.sh
+++ b/deployment/deploy_requestor.sh
@@ -1,1 +1,20 @@
-NEAR_ENV=$1 near deploy --accountId $2 --wasmFile ./res/requestor_contracts.wasm --initFunction new --initArgs '{"oracle": '$3', "stake_token": "v2.wnear.flux-dev"}'
+#!/bin/bash
+
+# default params
+network=${network:-testnet}
+accountId=${accountId:-oracle.account.testnet}
+oracle=${oracle:-flux-dev}
+stakeToken=${stakeToken:-v2.wnear.flux-dev}
+
+while [ $# -gt 0 ]; do
+
+   if [[ $1 == *"--"* ]]; then
+        param="${1/--/}"
+        declare $param="$2"
+        # echo $1 $2 // Optional to see the parameter:value result
+   fi
+
+  shift
+done
+
+NEAR_ENV=$network near deploy --accountId $accountId --wasmFile ./res/requestor_contracts.wasm --initFunction new --initArgs '{"oracle": "'$oracle'", "stake_token": "'$stakeToken'"}'

--- a/deployment/reset_account.sh
+++ b/deployment/reset_account.sh
@@ -1,2 +1,21 @@
-NEAR_ENV=$1 near delete $2 $3
-NEAR_ENV=$1 near create_account $2 --masterAccount $3
+#!/bin/bash
+
+# default params
+network=${network:-testnet}
+account=${accountId:-flux-dev}
+master=${master:-flux-dev}
+initialBalance=${initialBalance:-5}
+
+while [ $# -gt 0 ]; do
+
+   if [[ $1 == *"--"* ]]; then
+        param="${1/--/}"
+        declare $param="$2"
+        # echo $1 $2 // Optional to see the parameter:value result
+   fi
+
+  shift
+done
+
+NEAR_ENV=$network near delete $account $master
+NEAR_ENV=$network near create-account $account --masterAccount $master --initialBalance $initialBalance


### PR DESCRIPTION
- fix invalid JSON input for argument in `deploy_requestor.sh`
- added named command line args for easier debugging without modifying scripts with default values defined internally
- gave examples of usage in `deployment/README.md`